### PR TITLE
Modification to allow for custom dialects.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Configuration.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Configuration.java
@@ -87,7 +87,6 @@ public class Configuration {
             throw new InitException(e);
         }
 
-
         String cacheManagerClass = properties.getProperty("cache.manager");
         if(cacheManagerClass != null){
 
@@ -100,6 +99,24 @@ public class Configuration {
             }
 
         }
+        
+        String dialectClasses = properties.getProperty("dialects");
+        if (dialectClasses != null) {
+            try {
+                ClassLoader classLoader = Configuration.class.getClassLoader();
+                
+                for (String dialect : dialectClasses.split(";")) {
+                    String[] nc = dialect.split(",");
+                    Class dClass = classLoader.loadClass(nc[1]);
+                    dialects.put(nc[0], (DefaultDialect)dClass.newInstance());
+                }                
+            } catch (Exception e) {
+                throw new InitException("failed to initialize custom Dialects. Please, ensure that the property " +
+                        "'dialects' is in the format 'name,class;...' and points to the correct classes which extends 'activejdbc.dialects.DefaultDialect' class and provides a default constructor.", e);
+            }
+
+        }
+        
     }
 
     List<String> getModelNames(String dbName) throws IOException {
@@ -119,28 +136,32 @@ public class Configuration {
     }
 
     DefaultDialect getDialect(MetaModel mm){
-        if(dialects.get(mm.getDbType()) == null){
-            if(mm.getDbType().equalsIgnoreCase("Oracle")){
-                dialects.put(mm.getDbType(), new OracleDialect());
+        return getDialect(mm.getDbType());
+    }
+    
+    DefaultDialect getDialect(String dbType){
+        if(dialects.get(dbType) == null){
+            if(dbType.equalsIgnoreCase("Oracle")){
+                dialects.put(dbType, new OracleDialect());
             }
-            else if(mm.getDbType().equalsIgnoreCase("MySQL")){
-                dialects.put(mm.getDbType(), new MySQLDialect());
+            else if(dbType.equalsIgnoreCase("MySQL")){
+                dialects.put(dbType, new MySQLDialect());
             }
-            else if(mm.getDbType().equalsIgnoreCase("PostgreSQL")){
-                dialects.put(mm.getDbType(), new PostgreSQLDialect());
+            else if(dbType.equalsIgnoreCase("PostgreSQL")){
+                dialects.put(dbType, new PostgreSQLDialect());
             }
-            else if(mm.getDbType().equalsIgnoreCase("h2")){
-                dialects.put(mm.getDbType(), new H2Dialect());
+            else if(dbType.equalsIgnoreCase("h2")){
+                dialects.put(dbType, new H2Dialect());
             }
-            else if(mm.getDbType().equalsIgnoreCase("Microsoft SQL Server")){
-                dialects.put(mm.getDbType(), new MSSQLDialect());
+            else if(dbType.equalsIgnoreCase("Microsoft SQL Server")){
+                dialects.put(dbType, new MSSQLDialect());
             }
             else{
-                dialects.put(mm.getDbType(), new DefaultDialect());
+                dialects.put(dbType, new DefaultDialect());
             }
         }
 
-        return dialects.get(mm.getDbType());
+        return dialects.get(dbType);
     }
 
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/dialects/DefaultDialect.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/dialects/DefaultDialect.java
@@ -17,6 +17,8 @@ limitations under the License.
 
 package org.javalite.activejdbc.dialects;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import org.javalite.activejdbc.MetaModel;
 import org.javalite.common.Util;
 
@@ -113,4 +115,8 @@ public class DefaultDialect {
    public Object overrideDriverTypeConversion(MetaModel mm, String attributeName, Object value) {
 	   return value;
    }
+   
+   public Object getObject(ResultSet rs, int columnIndex) throws SQLException {
+       return rs.getObject(columnIndex);
+   }   
 }

--- a/activejdbc/src/test/java/org/javalite/activejdbc/CustomDialectTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/CustomDialectTest.java
@@ -1,0 +1,37 @@
+/*
+Copyright 2009-2010 Igor Polevoy 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
+
+package org.javalite.activejdbc;
+
+import org.javalite.activejdbc.dialects.H2Dialect;
+import org.javalite.activejdbc.dialects.MySQLDialect;
+import static org.javalite.test.jspec.JSpec.a;
+import org.junit.Test;
+
+/**
+ *
+ * @author Rob Wandell
+ */
+public class CustomDialectTest {
+    
+    @Test
+    public void testDialectConfiguration() {        
+        a(Registry.instance().getConfiguration().getDialect("TestMySQL")).shouldBeA(MySQLDialect.class);
+        a(Registry.instance().getConfiguration().getDialect("TestH2")).shouldBeA(H2Dialect.class);
+    }    
+    
+}

--- a/activejdbc/src/test/resources/activejdbc.properties
+++ b/activejdbc/src/test/resources/activejdbc.properties
@@ -1,4 +1,3 @@
-
 ####################################################################################################
 # cache.manager provides a class name of a class that extends org.javalite.activejdbc.cache.CacheManager class.
 # this property will override all @Cached annotations. If this property exists
@@ -6,7 +5,7 @@
 # have the @Cached annotations. If this property does not exist, then no caching will be
 # performed across runtime, regardless of @Cached annotations. Think of this as a global switch.
 #
-# dialects provides a way to specify a customer dialect that isn't officially supported by activejdbc.
+# dialects provides a way to specify a custom dialect that isn't officially supported by activejdbc.
 # this property will add the name and class to the list of supported dialects. the property supports
 # a comma and semicolon delimitted list (name,class;...)
 ###################################################################################################### 

--- a/activejdbc/src/test/resources/activejdbc.properties
+++ b/activejdbc/src/test/resources/activejdbc.properties
@@ -5,8 +5,14 @@
 # then ActiveJDBC will obey annotations and will enable caching for those models that
 # have the @Cached annotations. If this property does not exist, then no caching will be
 # performed across runtime, regardless of @Cached annotations. Think of this as a global switch.
-##################################################################################################### 
+#
+# dialects provides a way to specify a customer dialect that isn't officially supported by activejdbc.
+# this property will add the name and class to the list of supported dialects. the property supports
+# a comma and semicolon delimitted list (name,class;...)
+###################################################################################################### 
 
 cache.manager=org.javalite.activejdbc.cache.OSCacheManager
+
+dialects=TestMySQL,org.javalite.activejdbc.dialects.MySQLDialect;TestH2,org.javalite.activejdbc.dialects.H2Dialect
 
 collectStatistics = true


### PR DESCRIPTION
Because some JDBC drivers like Informix require a license, AciveJDBC can't add a dialect for it since it can't be fully supported.  This modification allows for adding custom dialects to ActiveJDBC.

Added a getObject to DefaultDialect to allow for overriding the ResultSet getObject method and added a dialects property to the activejdbc.properties file to allow  custom dialects that are not officially supported by ActiveJDBC.

Informix Dialect:

public class InformixDialect extends DefaultDialect {

```
/**
 * Generates adds limit, offset and order bys to a sub-query
 *
 * @param tableName name of table. If table name is null, then the subQuery parameter is considered to be a full query, and all that needs to be done is to
 * add limit, offset and order bys
 * @param subQuery sub-query or a full query
 * @param orderBys
 * @param limit
 * @param offset
 * @return query with
 */
@Override
public String formSelect(String tableName, String subQuery, List<String> orderBys, long limit, long offset) {

    String fullQuery;
    if (tableName == null){
        fullQuery = subQuery;
    } else {
        fullQuery = "SELECT";

        if(offset != -1){
            fullQuery += " SKIP " + offset;
        }
        if(limit != -1){
            fullQuery += " LIMIT " + limit;
        }

        fullQuery += " * FROM " + tableName;
        if (!Util.blank(subQuery)) {
            String where = " WHERE ";

            if (!groupByPattern.matcher(subQuery.toLowerCase().trim()).find() &&
                    !orderByPattern.matcher(subQuery.toLowerCase().trim()).find()) {
                fullQuery += where;
            }
            fullQuery += " " + subQuery;
        }
    }

    if(!orderBys.isEmpty()){
        fullQuery += " ORDER BY " + Util.join(orderBys, ", ");
    }

    return fullQuery;
}

@Override
public Object getObject(ResultSet rs, int columnIndex) throws SQLException {
    Object value = super.getObject(rs, columnIndex);

    // Informix 3.70.JC8 getObject returns a String for TEXT objects instead of bytes.
    // This causes problems when the object is encoded.
    if (value == null && rs.getMetaData().getColumnTypeName(columnIndex).equalsIgnoreCase("TEXT")) {
        value = rs.getBytes(columnIndex);
    }

    return value;
}
```

}
