### PR TITLE
#874 Fix build in failure due to dokka-maven-plugin on JDK 11

### DIFF
--- a/activejdbc-kt/pom.xml
+++ b/activejdbc-kt/pom.xml
@@ -13,12 +13,13 @@
 
     <properties>
         <!-- Kotlin version -->
-        <kotlin.version>1.2.51</kotlin.version>
-        <kotlin.compiler.languageVersion>1.2</kotlin.compiler.languageVersion>
+        <kotlin.version>1.3.50</kotlin.version>
+        <kotlin.compiler.languageVersion>1.3</kotlin.compiler.languageVersion>
+        <jvm.version>11</jvm.version>
 
         <!-- Kotlin version -->
-        <kotlin.src>${project.basedir}/src/main/kt</kotlin.src>
-        <kotlin.test>${project.basedir}/src/test/kt</kotlin.test>
+        <kotlin.source.directory>${project.basedir}/src/main/kt</kotlin.source.directory>
+        <kotlin.test.directory>${project.basedir}/src/test/kt</kotlin.test.directory>
 
         <!-- H2DB config for tests -->
         <jdbc.driver>org.h2.Driver</jdbc.driver>
@@ -50,7 +51,7 @@
             <url>https://jcenter.bintray.com/</url>
         </pluginRepository>
     </pluginRepositories>
-    
+
     <build>
         <testResources>
             <testResource>
@@ -58,24 +59,47 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
+
         <!-- Specify where kotlin sources are -->
-        <sourceDirectory>${kotlin.src}</sourceDirectory>
-        <testSourceDirectory>${kotlin.test}</testSourceDirectory>
+        <sourceDirectory>${kotlin.source.directory}</sourceDirectory>
+        <testSourceDirectory>${kotlin.test.directory}</testSourceDirectory>
 
         <plugins>
-            <!--plugin>
+            <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
                 <version>0.9.18</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>pre-site</phase>
                         <goals>
-                            <goal>javadocJar</goal>
+                            <goal>dokka</goal>
                         </goals>
                     </execution>
                 </executions>
-            </plugin-->
+                <configuration>
+                    <jdkVersion>${jvm.version}</jdkVersion>
+                    <outputFormat>html</outputFormat>
+                    <noStdlibLink>true</noStdlibLink>
+                    <noJdkLink>true</noJdkLink>
+                    <skipEmptyPackages>true</skipEmptyPackages>
+
+                    <impliedPlatforms>
+                        <platform>JVM</platform>
+                    </impliedPlatforms>
+
+                    <sourceDirectories>
+                        <dir>${kotlin.source.directory}</dir>
+                    </sourceDirectories>
+
+                    <sourceRoots>
+                        <root>
+                            <path>${kotlin.source.directory}</path>
+                            <platforms>JVM</platforms>
+                        </root>
+                    </sourceRoots>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -143,6 +167,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.8.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
I took out the dokka-maven-plugin from the Maven's `package` phase to set it to the `pre-site` phase to fix the main issue. Because the last version of this plugin is not working well with JDK 11 their is still both warnings and errors when you execute the `mvn site` command but beside that everything is generated correctly.

Note that I have to upgrade the Kotlin version to the 1.3.50 in order to be able to make the Kotlin's compiler targeting JDK 11 and not only JDK 1.6 and 1.8. This will help in future releases.