### PR TITLE
#962 - TravisCI - Ensure java8 build is done with JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-dist: xenial
 language: java
-jdk:
-  - openjdk11
+
+sudo: required # So we can use docker and a beefier machine
+dist: trusty
 
 git:
   depth: 1 # an optimization since we won't be committing anything


### PR DESCRIPTION
The aim of this PR is to fix issue #962 by ensuring the `java8` branch is compiled with JDK8.

I'm almost sure the JDK11 commit wasn't there previously :/