### PR TITLE
updates dependencies slf4j, mysql.connector, spring, maven-surefire-p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,17 +26,15 @@
         <version>7</version>
     </parent>
 
-
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <properties>
+	   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skipTests>false</skipTests>
         <slf4j.version>1.7.25</slf4j.version>
 
         <junit.version>4.12</junit.version>
         <junit-vintage-engine.version>5.3.2</junit-vintage-engine.version>
-        <mysql.connector.version>8.0.16</mysql.connector.version>
-        <spring.version>5.1.4.RELEASE</spring.version>
+        <mysql.connector.version>8.0.18</mysql.connector.version>
+        <spring.version>5.1.11.RELEASE</spring.version>
     </properties>
 
     <licenses>
@@ -69,7 +67,6 @@
     <build>
         <pluginManagement>
             <plugins>
-
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>3.6.0</version>
@@ -111,7 +108,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M4</version>
                     <configuration>
                         <detail>true</detail>
                         <useFile>false</useFile>
@@ -253,7 +250,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.5</version>
+                <version>42.2.8</version>
                 <scope>test</scope>
             </dependency>
 
@@ -273,17 +270,17 @@
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
-                <version>2.2.11</version>
+                <version>2.2.12</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-core</artifactId>
-                <version>2.2.11</version>
+                <version>2.2.12</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.2.11</version>
+                <version>2.2.12</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>
@@ -349,7 +346,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.11.3</version>
+                <version>1.12.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
…lugin, postgresql, h2, jaxb, freemarker, jsoup.

slf4j 1.7.25 -> 1.7.29
mysql.connector 8.0.16 -> 8.0.18
spring 5.1.4.RELEASE -> 5.1.11.RELEASE
maven-surefire-plugin 3.0.0-M3 -> 3.0.0-M4
postgresql 42.2.5 -> 42.2.8
h2 1.4.197 -> 1.4.200
jaxb-api,jaxb-core,jaxb-impl 2.2.11 -> 2.2.12
freemarker 2.3.28 -> 2.3.29
jsoup 1.11.3 -> 1.12.1