### PR TITLE
#966 - overloaded model constructor with MetaModel and ModelRegistry …

### DIFF
--- a/activejdbc/pom.xml
+++ b/activejdbc/pom.xml
@@ -467,6 +467,12 @@
             <version>0.9.1.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Two versions of EHCache because we support v2 and v3-->
         <dependency>
             <groupId>net.sf.ehcache</groupId>

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -81,6 +81,12 @@ public abstract class Model extends CallbackSupport implements Externalizable {
         modelRegistryLocal = Registry.instance().modelRegistryOf(this.getClass());
     }
 
+    protected Model(MetaModel metaModel, ModelRegistry modelRegistry)
+    {
+        this.metaModelLocal = Objects.requireNonNull(metaModel, "metaModel is null");
+        this.modelRegistryLocal = Objects.requireNonNull(modelRegistry, "modelRegistry is null");
+    }
+
     private void fireAfterLoad() {
         afterLoad();
         for (CallbackListener callback : modelRegistryLocal.callbacks()) {

--- a/activejdbc/src/main/java/org/javalite/activejdbc/ModelRegistry.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ModelRegistry.java
@@ -34,7 +34,7 @@ import org.javalite.activejdbc.validation.Validator;
  *
  * @author ericbn
  */
-class ModelRegistry {
+public class ModelRegistry {
     private final List<CallbackListener> callbacks = new ArrayList<>();
     private final Map<String, List<Converter>> attributeConverters = new CaseInsensitiveMap<>();
     private final List<Validator> validators = new ArrayList<>();

--- a/activejdbc/src/test/java/org/javalite/activejdbc/MockedMetaModelTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/MockedMetaModelTest.java
@@ -1,0 +1,67 @@
+package org.javalite.activejdbc;
+
+import org.javalite.activejdbc.test_models.Library;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.javalite.test.jspec.JSpec.the;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MockedMetaModelTest {
+
+    @Mock
+    private MetaModel metaModelMock;
+    @Mock
+    private ModelRegistry registryMock;
+
+    private Library library;
+
+    @Before
+    public void setUp()
+    {
+        library = new Library(metaModelMock, registryMock);
+    }
+
+    @Test
+    public void shouldSetAndReadModelPropertiesWithoutMetaModel()
+    {
+        library.setString("address", "5th Avenue");
+        library.setString("city", "New York City");
+        library.setString("state", "New York");
+
+        the(library.getString("address")).shouldBeEqual("5th Avenue");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void mockShouldThrowIllegalStateExceptionSavingModel()
+    {
+        when(metaModelMock.getIdName()).thenThrow(new IllegalStateException("Meta model not available"));
+
+        library.setString("address", "5th Avenue");
+
+        library.saveIt();
+    }
+
+    @Test
+    public void toStringShouldWork()
+    {
+        library.setString("address", "5th Avenue");
+
+        the(library.toString()).shouldNotBeNull();
+    }
+
+    @Test
+    public void mockTableName()
+    {
+        when(metaModelMock.getTableName()).thenReturn("<no meta data>");
+
+        library.setString("address", "5th Avenue");
+
+        the(library.toString().contains("<no meta data>")).shouldBeTrue();
+    }
+
+}

--- a/activejdbc/src/test/java/org/javalite/activejdbc/test_models/Library.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/test_models/Library.java
@@ -17,9 +17,18 @@ limitations under the License.
 
 package org.javalite.activejdbc.test_models;
 
+import org.javalite.activejdbc.MetaModel;
 import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.ModelRegistry;
 import org.javalite.activejdbc.annotations.Cached;
 
 @Cached
 public class Library extends Model {
+
+    public Library() {
+    }
+
+    public Library(MetaModel metaModel, ModelRegistry modelRegistry) {
+        super(metaModel, modelRegistry);
+    }
 }


### PR DESCRIPTION
@ipolevoy, could you review the PR. The test MockedMetaModelTest is a proof of concept and demonstrates how i will use model classes without meta data retrieved from DB in business-logic tests.
I'm not sure if you like the new test dependency mockito-core.