### PR TITLE
Handle concurrent calls to getModelRegistry

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/MetaModels.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/MetaModels.java
@@ -24,9 +24,11 @@ import org.javalite.json.JSONHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.emptyList;
 import static org.javalite.common.Collections.map;
@@ -51,7 +53,7 @@ class MetaModels {
     private final Map<String, MetaModel> metaModelsByClassName = new HashMap<>();
     //these are all many to many associations across all models.
     private final List<Many2ManyAssociation> many2ManyAssociations = new ArrayList<>();
-    private final Map<Class, ModelRegistry> modelRegistries = new HashMap<>();
+    private final Map<Class, ModelRegistry> modelRegistries = new ConcurrentHashMap<>();
 
     void addMetaModel(MetaModel mm, Class<? extends Model> modelClass) {
         Object o = metaModelsByClassName.put(modelClass.getName(), mm);


### PR DESCRIPTION
When our service spins up, we immediately spin up some threads to perform scheduled jobs. When these threads use ActiveJDBC models, sometimes we see concurrency errors. Here's a sample stacktrace:

```
java.util.ConcurrentModificationException: null
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1225)
        at org.javalite.activejdbc.MetaModels.getModelRegistry(MetaModels.java:68)
        at org.javalite.activejdbc.Registry.modelRegistryOf(Registry.java:106)
        at org.javalite.activejdbc.Model.(Model.java:81)
        at com.ktbyte.earth.model.ClassSessionStudentSwap.(ClassSessionStudentSwap.java:17)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:64)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128)
        at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:350)
        at java.base/java.lang.Class.newInstance(Class.java:645)
        at org.javalite.activejdbc.ModelDelegate.instance(ModelDelegate.java:239)
        at org.javalite.activejdbc.ModelDelegate.instance(ModelDelegate.java:234)
        at org.javalite.activejdbc.LazyList$1.onNext(LazyList.java:325)
        at org.javalite.activejdbc.RowListenerAdapter.next(RowListenerAdapter.java:30)
        at org.javalite.activejdbc.RowProcessor.processRS(RowProcessor.java:96)
        at org.javalite.activejdbc.RowProcessor.with(RowProcessor.java:71)
        at org.javalite.activejdbc.LazyList.hydrate(LazyList.java:323)
        at org.javalite.activejdbc.AbstractLazyList.size(AbstractLazyList.java:36)
        at ...
```

This change should make the map safely handle concurrent access when multiple threads are initializing ActiveJDBC models.