### PR TITLE
Could org.javalite:db-migrator-maven-plugin-test-project:1.0-SNAPSHOTdrop off redundant dependencies? 

### DIFF
--- a/db-migrator-integration-test/src/test/project/test-project/pom.xml
+++ b/db-migrator-integration-test/src/test/project/test-project/pom.xml
@@ -30,11 +30,4 @@
 
         </plugins>
     </build>
-    <dependencies>
-        <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>2.3.28</version>
-        </dependency>
-    </dependencies>
 </project>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.javalite:db-migrator-maven-plugin-test-project:1.0-SNAPSHOT_** introduced **_2_** dependencies. However, among them, **_1_** libraries (**_50%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.freemarker:freemarker:jar:2.3.28:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.freemarker:freemarker:jar:2.3.28:compile_** incorporates a high-level vulnerability SNYK-JAVA-ORGFREEMARKER-1076795. As such, I suggest a refactoring operation for **_org.javalite:db-migrator-maven-plugin-test-project:1.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.javalite:db-migrator-maven-plugin-test-project:1.0-SNAPSHOT_**’s maven tests.

Best regards