### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <junit-vintage-engine.version>5.7.0</junit-vintage-engine.version>
         <mariadb.connector.version>2.7.4</mariadb.connector.version>
         <h2.version>2.1.210</h2.version>
-        <spring.version>5.3.26</spring.version>
+        <spring.version>6.0.0</spring.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 5.3.26
- [CVE-2016-1000027](https://www.oscs1024.com/hd/CVE-2016-1000027)


### What did I do？
Upgrade org.springframework:spring-web from 5.3.26 to 6.0.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS