### PR TITLE
#1294 - Lost controllers with non-public classes in inheritance and packet routing

### DIFF
--- a/activeweb/src/main/java/org/javalite/activeweb/Configuration.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/Configuration.java
@@ -345,7 +345,8 @@ public class Configuration {
         CloseableList<ClassInfo> controllerInfos = new CloseableList<>();
         String controllerRootPackage = Configuration.getRootPackage() + ".controllers";
 
-        ClassGraph classGraph = new ClassGraph().acceptPackages(controllerRootPackage).enableClassInfo().enableMethodInfo().enableAnnotationInfo();
+        ClassGraph classGraph = new ClassGraph().acceptPackages(controllerRootPackage)
+                .enableClassInfo().enableMethodInfo().enableAnnotationInfo().ignoreClassVisibility();
 
         if (classLoader != null) {
             classGraph.overrideClassLoaders(classLoader);
@@ -353,7 +354,7 @@ public class Configuration {
 
         ScanResult scanResult = classGraph.scan();
         for (ClassInfo classInfo : scanResult.getSubclasses(AppController.class.getName())) {
-            if (!classInfo.isAbstract()) {
+            if (!classInfo.isAbstract() && classInfo.isPublic()) {
                 classInfo.getAnnotationInfo();
                 controllerInfos.add(classInfo);
             }

--- a/activeweb/src/test/java/app/controllers/issue1294/AbstractPrivateController.java
+++ b/activeweb/src/test/java/app/controllers/issue1294/AbstractPrivateController.java
@@ -1,0 +1,9 @@
+package app.controllers.issue1294;
+
+import org.javalite.activeweb.AppController;
+
+/**
+ * @author Andrey Yanchevsky
+ */
+class AbstractPrivateController extends AppController {
+}

--- a/activeweb/src/test/java/app/controllers/issue1294/TestController.java
+++ b/activeweb/src/test/java/app/controllers/issue1294/TestController.java
@@ -1,0 +1,10 @@
+package app.controllers.issue1294;
+
+/**
+ * @author Andrey Yanchevsky
+ */
+public class TestController extends AbstractPrivateController {
+    public void index() {
+        respond("OK");
+    }
+}

--- a/activeweb/src/test/java/org/javalite/activeweb/RouterControllerPathSpec.java
+++ b/activeweb/src/test/java/org/javalite/activeweb/RouterControllerPathSpec.java
@@ -78,4 +78,11 @@ public class RouterControllerPathSpec {
         router.getControllerPathByURI("/admin/");//this should fail because "admin" package exists, and
         //no controller is specified after.
     }
+
+    @Test
+    public void shouldFindControllersWithNonPublicClassesInInheritanceAndPackageRouting() {
+        ControllerPath path = router.getControllerPathByURI("/issue1294/test");
+        a(path.getControllerPackage()).shouldBeEqual("issue1294");
+        a(path.getControllerName()).shouldBeEqual("test");
+    }
 }


### PR DESCRIPTION
[#1294 - Lost controllers with non-public classes in inheritance and packet routing](https://github.com/javalite/javalite/issues/1294)